### PR TITLE
Only consider stable releases

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func update(v string) {
 		latestVer, _ := version.NewVersion("0")
 		for _, rel := range a.Releases {
 			ver, _ := version.NewVersion(rel.Version)
-			if ver.GreaterThan(latestVer) {
+			if ver.GreaterThan(latestVer) && len(ver.Prerelease()) == 0 {
 				latestVer = ver
 				na.Version = ver.String()
 				na.Url = rel.Download


### PR DESCRIPTION
Added a check to the version compare function to only consider stable releases (if no prerelease tag is present)

Fixes https://github.com/helsinki-systems/nc4nix/issues/4