### PR TITLE
feat: adopt flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,36 +1,20 @@
-{ lib, fetchurl, runCommand, callPackage, overrides ? (self: super: {}) }:
-let apps = (self:
-  let
-    appJson = version: builtins.fromJSON (builtins.readFile (./. + "/${version}.json"));
-    versions = (callPackage ./nc-versions.nix {}).n;
-    apps = builtins.listToAttrs (map (v: let
-      majorVer = lib.versions.major v;
-    in {
-      name = majorVer;
-      value = builtins.mapAttrs mkApp (appJson majorVer);
-    }) versions);
+{ pkgs ? (
+    let
+      inherit (builtins) fetchTree fromJSON readFile;
+      inherit ((fromJSON (readFile ./flake.lock)).nodes) nixpkgs gomod2nix;
+    in
+    import (fetchTree nixpkgs.locked) {
+      overlays = [
+        (import "${fetchTree gomod2nix.locked}/overlay.nix")
+      ];
+    }
+  )
+}:
 
-    mkApp = name: value: runCommand "nc-app-${name}-${value.version}" {
-      src = fetchurl {
-        inherit (value) url sha256;
-      };
-      inherit (value) version;
-    } /* sh */ ''
-      mkdir _unp
-      tar -xpf "$src" -C _unp
-      if [ $(find _unp -mindepth 1 -maxdepth 1 -type d | wc -l) != 1 ]; then
-        echo "error: zip file must contain a single directory"
-        exit 1
-      fi
-      mkdir -p $out
-      cp -R _unp/*/. $out/
-
-      if [ ! -f "$out/appinfo/info.xml" ]; then
-        echo "appinfo/info.xml doesn't exist in $out, aborting!"
-        exit 2
-      fi
-    '';
-  in
-    apps
-  );
-in lib.fix' (lib.extends overrides apps)
+pkgs.buildGoApplication {
+  pname = "nc4nix";
+  version = "unstable-2023-06-06";
+  pwd = ./.;
+  src = ./.;
+  modules = ./gomod2nix.toml;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1677459247,
+        "narHash": "sha256-JbakfAiPYmCCV224yAMq/XO0udN5coWv/oazblMKdoY=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "3cbf3a51fe32e2f57af4c52744e7228bab22983d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1658285632,
+        "narHash": "sha256-zRS5S/hoeDGUbO+L95wXG9vJNwsSYcl93XiD0HQBXLk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5342fc6fb59d0595d26883c3cadff16ce58e44f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1690031011,
+        "narHash": "sha256-kzK0P4Smt7CL53YCdZCBbt9uBFFhE0iNvCki20etAf4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12303c652b881435065a98729eb7278313041e49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gomod2nix": "gomod2nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "A basic gomod2nix flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.gomod2nix.url = "github:nix-community/gomod2nix";
+
+  outputs = { self, nixpkgs, flake-utils, gomod2nix }:
+    (flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ gomod2nix.overlays.default ];
+          };
+
+        in
+        {
+          packages.default = pkgs.callPackage ./. { };
+          devShells.default = import ./shell.nix { inherit pkgs; };
+        })
+    );
+}

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -1,0 +1,3 @@
+schema = 1
+
+[mod]

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,22 @@
-with import <nixpkgs> { };
+{ pkgs ? (
+    let
+      inherit (builtins) fetchTree fromJSON readFile;
+      inherit ((fromJSON (readFile ./flake.lock)).nodes) nixpkgs gomod2nix;
+    in
+    import (fetchTree nixpkgs.locked) {
+      overlays = [
+        (import "${fetchTree gomod2nix.locked}/overlay.nix")
+      ];
+    }
+  )
+}:
 
-stdenv.mkDerivation {
-  name = "go";
-  buildInputs = [
-    delve
-    libcap
-    go
-    gcc
+let
+  goEnv = pkgs.mkGoEnv { pwd = ./.; };
+in
+pkgs.mkShell {
+  packages = [
+    goEnv
+    pkgs.gomod2nix
   ];
-  shellHook = ''
-    export GOPATH=$PWD/gopath
-  '';
 }


### PR DESCRIPTION
I was trying to contribute to nc4nix but prefer flakes. Flakes make this even more reproducable. 

I "flakified" the repo with gomod2nix. 
The update removed  ` delve   libcap` from shell.nix , but `go build` works without it ? 

The stuff in default.nix I am not sure what it's about
I dont develop in go, `go run` seemed like the good command to start nc4nix but it does nothing both on main and in this branch ? 